### PR TITLE
Add update handler test

### DIFF
--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -42,4 +42,26 @@ describe('Runner', () => {
       expect(result.error.message).toBe('Max retries reached');
     }
   });
+
+  it('calls update handler on success', async () => {
+    const node = new ActionNode('start', async () => 'done');
+    const flow = new Flow('simple').addNode(node).setStartNode('start');
+
+    const context: Context = {
+      conversationHistory: [],
+      data: {},
+      metadata: {},
+    };
+
+    const runner = new Runner();
+    const onUpdate = jest.fn();
+    runner.onUpdate(onUpdate);
+
+    await runner.runFlow(flow, context);
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      type: 'chunk',
+      content: 'Flow completed',
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- ensure Runner's update handler is triggered for successful flows

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b57411cc832cb981297f988fe7e2