### PR TITLE
Handle non-array items in BatchNode

### DIFF
--- a/src/nodes/batch.ts
+++ b/src/nodes/batch.ts
@@ -204,8 +204,17 @@ export class BatchNode<TInput = unknown, TOutput = unknown> extends Node {
    */
   async execute(context: Context): Promise<NodeResult> {
     try {
-      const items = (context.data[this.itemsKey] || []) as BatchItem<TInput>[];
-      const results = await Promise.all(items.map((item) => this.processItem(item, context)));
+      const rawItems = context.data[this.itemsKey];
+
+      if (!Array.isArray(rawItems)) {
+        return { type: 'success', output: [] };
+      }
+
+      const items = rawItems as BatchItem<TInput>[];
+      const results = await Promise.all(
+        items.map((item) => this.processItem(item, context)),
+      );
+
       return { type: 'success', output: results };
     } catch (error) {
       return {

--- a/tests/nodes.test.ts
+++ b/tests/nodes.test.ts
@@ -151,6 +151,20 @@ describe('Nodes', () => {
         expect(result.output).toEqual([]);
       }
     });
+
+    it('handles non-array items gracefully', async () => {
+      const ctx: Context = {
+        conversationHistory: [],
+        data: { items: 123 },
+        metadata: {},
+      };
+      const node = new BatchNode<number, number>('non-array', 'items', async (item) => item * 2);
+      const result = await node.execute(ctx);
+      expect(result.type).toBe('success');
+      if (result.type === 'success') {
+        expect(result.output).toEqual([]);
+      }
+    });
   });
 
   it('ActionNode handles error gracefully', async () => {


### PR DESCRIPTION
## Summary
- avoid calling `.map` when batch input isn't an array
- test that BatchNode handles non-array inputs

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842b56b1ee4832cb8b3562d347b963e