### PR TITLE
Add publish alias to MessageBus

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,14 +173,14 @@ import { MessageBus } from 'ai-agent-flow/utils/message-bus';
 const bus = new MessageBus();
 
 // Subscribe to a topic
-bus.subscribe('greetings', (message) => {
-  console.log(`Received message: ${message}`);
+bus.subscribe('greetings', (sender, message) => {
+  console.log(`Received from ${sender}: ${message}`);
 });
 
 // Publish a message to the topic
 bus.publish('greetings', 'Hello, World!');
 
-// Output: Received message: Hello, World!
+// Output: Received from system: Hello, World!
 ```
 
 This is particularly useful for multi-agent systems where agents need to communicate asynchronously.

--- a/src/utils/message-bus.ts
+++ b/src/utils/message-bus.ts
@@ -5,6 +5,16 @@ export class MessageBus extends EventEmitter {
     this.emit(receiverId, senderId, message);
   }
 
+  /**
+   * Alias for {@link send} to match documentation examples.
+   *
+   * @param receiverId - The id of the receiver agent
+   * @param message - The message payload
+   */
+  publish(receiverId: string, message: unknown): void {
+    this.send('system', receiverId, message);
+  }
+
   subscribe(receiverId: string, callback: (senderId: string, message: unknown) => void): void {
     this.on(receiverId, callback);
   }

--- a/tests/message-bus.test.ts
+++ b/tests/message-bus.test.ts
@@ -10,4 +10,14 @@ describe('MessageBus', () => {
     });
     bus.send('agentA', 'agentB', 'hello');
   });
+
+  it('should publish messages without sender id', (done) => {
+    const bus = new MessageBus();
+    bus.subscribe('news', (senderId, message) => {
+      expect(senderId).toBe('system');
+      expect(message).toBe('update');
+      done();
+    });
+    bus.publish('news', 'update');
+  });
 });


### PR DESCRIPTION
## Summary
- support publishing messages directly on MessageBus
- document publish in README
- test new publish helper

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6842b3fb1774832cbba0b6c33b37e769