### PR TITLE
Ensure tests and build run without OPENAI env

### DIFF
--- a/src/nodes/llm.ts
+++ b/src/nodes/llm.ts
@@ -2,7 +2,14 @@ import { Node } from './base';
 import { Context, NodeResult } from '../types';
 import OpenAI from 'openai';
 
-const openai = new OpenAI();
+let openai: OpenAI | null = null;
+
+function getOpenAI(): OpenAI {
+  if (!openai) {
+    openai = new OpenAI();
+  }
+  return openai;
+}
 
 export class LLMNode extends Node {
   constructor(
@@ -27,7 +34,7 @@ export class LLMNode extends Node {
 
       context.conversationHistory.push({ role: 'user', content: prompt });
 
-      const res = await openai.chat.completions.create({
+      const res = await getOpenAI().chat.completions.create({
         model: 'gpt-3.5-turbo',
         messages: context.conversationHistory,
       });

--- a/tests/nodes.test.ts
+++ b/tests/nodes.test.ts
@@ -2,7 +2,6 @@ import { ActionNode } from '../src/nodes/action';
 import { DecisionNode } from '../src/nodes/decision';
 import { BatchNode, BatchItem, BatchResult } from '../src/nodes/batch';
 import { Context } from '../src/types';
-import { LLMNode } from '../src/nodes/llm';
 
 jest.mock('openai', () => {
   return jest.fn().mockImplementation(() => {
@@ -22,6 +21,8 @@ jest.mock('openai', () => {
     };
   });
 });
+
+import { LLMNode } from '../src/nodes/llm';
 
 describe('Nodes', () => {
   const context: Context = {


### PR DESCRIPTION
## Summary
- mock `openai` before importing `LLMNode` in tests
- lazily instantiate OpenAI client

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842b9820940832ca95f29fd47ed359d