### PR TITLE
Add context store and persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm install ai-agent-flow
 ### 🤖 Quick Start Example
 
 ```typescript
-import { Flow, Runner } from 'ai-agent-flow';
+import { Flow, Runner, InMemoryContextStore } from 'ai-agent-flow';
 import { ActionNode } from 'ai-agent-flow/nodes/action';
 
 // Create nodes
@@ -70,7 +70,8 @@ const context = {
   metadata: {},
 };
 
-const result = await new Runner().runFlow(flow, context);
+const store = new InMemoryContextStore();
+const result = await new Runner(3, 1000, store).runFlow(flow, context, 'demo');
 console.log(result); // { type: 'success', output: '2024-03-20T...' }
 ```
 
@@ -80,6 +81,21 @@ console.log(result); // { type: 'success', output: '2024-03-20T...' }
 flowchart TD
   A[greetNode] -->|default| B[timeNode]
   B -->|default| C[End]
+```
+
+### Persisting Context
+
+Use a `ContextStore` to save and resume flows. Here we reuse the memory store:
+
+```typescript
+const store = new InMemoryContextStore();
+const runner = new Runner(3, 1000, store);
+
+// first run
+await runner.runFlow(flow, context, 'demo');
+
+// later resume using the same id
+await runner.runFlow(flow, {}, 'demo');
 ```
 
 ---

--- a/examples/chatbot.ts
+++ b/examples/chatbot.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import { Flow, Runner } from '../src/index';
+import { Flow, Runner, InMemoryContextStore } from '../src/index';
 import { LLMNode } from '../src/nodes/llm';
 import { DecisionNode } from '../src/nodes/decision';
 import { ActionNode } from '../src/nodes/action';
@@ -30,8 +30,9 @@ import { Context } from '../src/types';
     .addTransition('llm', { action: 'default', to: 'route' })
     .addTransition('route', { action: 'weather', to: 'weather' });
 
-  const runner = new Runner();
-  const result = await runner.runFlow(flow, context);
+  const store = new InMemoryContextStore();
+  const runner = new Runner(3, 1000, store);
+  const result = await runner.runFlow(flow, context, 'chat');
 
   console.log('🧠 AI said:', context.conversationHistory.at(-1)?.content);
   console.log(result);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.5.0",
+        "ioredis": "^5.6.1",
         "openai": "^4.95.1"
       },
       "devDependencies": {
@@ -1100,6 +1101,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
+      "license": "MIT"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -3592,6 +3599,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3963,7 +3979,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -4054,6 +4069,15 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/detect-newline": {
@@ -6163,6 +6187,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.6.1.tgz",
+      "integrity": "sha512-UxC0Yv1Y4WRJiGQxQkP0hfdL0/5/6YvdfOOClRgJ0qppSarkhneSa6UvkMkms0AkdGimSH3Ikqm+6mkMmX7vGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -7774,11 +7822,23 @@
       "integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
       "dev": true
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
       "dev": true
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -12005,6 +12065,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -12968,6 +13049,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/stream-combiner2": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,21 @@
       "require": "./dist/cjs/nodes/batch.js",
       "types": "./dist/types/nodes/batch.d.ts"
     },
+    "./store/memory": {
+      "import": "./dist/esm/store/memory.js",
+      "require": "./dist/cjs/store/memory.js",
+      "types": "./dist/types/store/memory.d.ts"
+    },
+    "./store/redis": {
+      "import": "./dist/esm/store/redis.js",
+      "require": "./dist/cjs/store/redis.js",
+      "types": "./dist/types/store/redis.d.ts"
+    },
+    "./store": {
+      "import": "./dist/esm/store/index.js",
+      "require": "./dist/cjs/store/index.js",
+      "types": "./dist/types/store/index.d.ts"
+    },
     "./types": {
       "import": "./dist/esm/types.js",
       "require": "./dist/cjs/types.js",
@@ -80,6 +95,7 @@
   },
   "dependencies": {
     "dotenv": "^16.5.0",
+    "ioredis": "^5.6.1",
     "openai": "^4.95.1"
   },
   "devDependencies": {
@@ -112,6 +128,7 @@
     "README.md",
     "LICENSE",
     "assets",
-    "nodes"
+    "nodes",
+    "store"
   ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export * from './nodes/decision';
 export * from './nodes/batch';
 export * from './types';
 export * from './utils/message-bus';
+export * from './store';
 
 import type { Context, NodeResult, Transition } from './types';
 import { Node } from './nodes/base';
@@ -72,19 +73,36 @@ export class Runner {
   constructor(
     private maxRetries = 3,
     private retryDelay = 1000,
+    private store?: import('./store').ContextStore,
   ) {}
 
-  async runFlow(flow: Flow, context: Context): Promise<NodeResult> {
+  async runFlow(flow: Flow, context: Context, contextId?: string): Promise<NodeResult> {
+    if (this.store && contextId) {
+      const loaded = await this.store.load(contextId);
+      if (loaded) {
+        context = loaded;
+      }
+    }
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
       const result = await flow.run(context);
       if (result.type === 'success') {
         if (this.updateHandler) {
           this.updateHandler({ type: 'chunk', content: result.output as string });
         }
+        if (this.store && contextId) {
+          await this.store.save(contextId, context);
+        }
         return result;
       }
       if (attempt < this.maxRetries) await new Promise((res) => setTimeout(res, this.retryDelay));
     }
-    return { type: 'error', error: new Error('Max retries reached') };
+    const errorResult: NodeResult = {
+      type: 'error',
+      error: new Error('Max retries reached'),
+    };
+    if (this.store && contextId) {
+      await this.store.save(contextId, context);
+    }
+    return errorResult;
   }
 }

--- a/src/store/context-store.ts
+++ b/src/store/context-store.ts
@@ -1,0 +1,6 @@
+import type { Context } from '../types';
+
+export interface ContextStore {
+  load(id: string): Promise<Context | null>;
+  save(id: string, context: Context): Promise<void>;
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,4 @@
+export type { ContextStore } from './context-store';
+export { InMemoryContextStore } from './memory';
+export { RedisContextStore } from './redis';
+export type { RedisContextStoreOptions } from './redis';

--- a/src/store/memory.ts
+++ b/src/store/memory.ts
@@ -1,0 +1,15 @@
+import type { Context } from '../types';
+import { ContextStore } from './context-store';
+
+/** Simple in-memory implementation of {@link ContextStore}. */
+export class InMemoryContextStore implements ContextStore {
+  private store = new Map<string, Context>();
+
+  async load(id: string): Promise<Context | null> {
+    return this.store.get(id) || null;
+  }
+
+  async save(id: string, context: Context): Promise<void> {
+    this.store.set(id, context);
+  }
+}

--- a/src/store/redis.ts
+++ b/src/store/redis.ts
@@ -1,0 +1,35 @@
+import Redis from 'ioredis';
+import type { Context } from '../types';
+import { ContextStore } from './context-store';
+
+/** Options for {@link RedisContextStore}. */
+export interface RedisContextStoreOptions {
+  /** Existing Redis client to use. */
+  client?: Redis;
+  /** Connection URL if a client is not provided. */
+  url?: string;
+}
+
+/** A Redis-backed implementation of {@link ContextStore}. */
+export class RedisContextStore implements ContextStore {
+  private client: Redis;
+
+  constructor(options: RedisContextStoreOptions = {}) {
+    if (options.client) {
+      this.client = options.client;
+    } else if (options.url) {
+      this.client = new Redis(options.url);
+    } else {
+      this.client = new Redis();
+    }
+  }
+
+  async load(id: string): Promise<Context | null> {
+    const data = await this.client.get(id);
+    return data ? (JSON.parse(data) as Context) : null;
+  }
+
+  async save(id: string, context: Context): Promise<void> {
+    await this.client.set(id, JSON.stringify(context));
+  }
+}

--- a/tests/context-store.test.ts
+++ b/tests/context-store.test.ts
@@ -1,0 +1,25 @@
+import { InMemoryContextStore } from '../src/store/memory';
+import { Flow, Runner } from '../src/index';
+import { ActionNode } from '../src/nodes/action';
+import type { Context } from '../src/types';
+
+describe('ContextStore and Runner integration', () => {
+  it('persists context between runs', async () => {
+    const store = new InMemoryContextStore();
+    const node = new ActionNode('start', async (ctx) => {
+      ctx.data.count = ((ctx.data.count as number | undefined) ?? 0) + 1;
+      return 'done';
+    });
+    const flow = new Flow('test').addNode(node).setStartNode('start');
+    const runner = new Runner(1, 10, store);
+
+    const context: Context = { conversationHistory: [], data: {}, metadata: {} };
+    await runner.runFlow(flow, context, 'id1');
+    let saved = await store.load('id1');
+    expect(saved?.data.count).toBe(1);
+
+    await runner.runFlow(flow, { conversationHistory: [], data: {}, metadata: {} }, 'id1');
+    saved = await store.load('id1');
+    expect(saved?.data.count).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- create `ContextStore` interface and memory/redis implementations
- enable Runner to load/save context via optional store
- expose new store utilities
- demonstrate persistence in docs and chatbot example
- add tests for context store integration

## Testing
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842bd460fb8832c8ccd7244794ced20