### PR TITLE
Add CLI runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,37 @@ Generate docs locally:
 npm run docs
 ```
 
+### CLI Usage
+
+Run a flow module directly from the command line:
+
+```bash
+npx aaflow run path/to/flow.ts
+```
+
+The module should export a `flow` instance (and optionally a `context` object):
+
+```typescript
+// flow.ts
+import { Flow, ActionNode } from 'ai-agent-flow';
+
+export const flow = new Flow('hello')
+  .addNode(new ActionNode('hello', async () => 'Hi'))
+  .setStartNode('hello');
+
+export const context = {
+  conversationHistory: [],
+  data: {},
+  metadata: {},
+};
+```
+
+Then run:
+
+```bash
+npx aaflow run ./flow.ts
+```
+
 ---
 
 ## 🔐 Extending

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",
+  "bin": {
+    "aaflow": "dist/cjs/cli.js"
+  },
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { Runner } from './index';
+import type { Flow, Context } from './index';
+
+export async function run(flowModulePath: string): Promise<void> {
+  const resolved = path.isAbsolute(flowModulePath)
+    ? flowModulePath
+    : path.resolve(process.cwd(), flowModulePath);
+  const mod = (await import(resolved)) as {
+    default?: Flow;
+    flow?: Flow;
+    context?: Context;
+  };
+  const flow: Flow | undefined = mod.flow ?? mod.default;
+  if (!flow) {
+    throw new Error('Flow instance not found. Export `flow` or default.');
+  }
+  const context: Context = mod.context ?? {
+    conversationHistory: [],
+    data: {},
+    metadata: {},
+  };
+  const runner = new Runner();
+  const result = await runner.runFlow(flow, context);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+if (require.main === module) {
+  const [, , command, file] = process.argv;
+  if (command !== 'run' || !file) {
+    console.log('Usage: aaflow run <path-to-flow-module>');
+    process.exit(command ? 1 : 0);
+  } else {
+    run(file).catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add `run` command to execute flows via CLI
- expose the CLI in `package.json`
- document CLI usage in README

## Testing
- `npm test`
- `npm run lint`
- `npm run build:types`
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_6842bd51ff04832cbc141c109c7ff61c