### PR TITLE
Implement multi-flow execution helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,19 @@ await runner.runFlow(flow, context, 'demo');
 await runner.runFlow(flow, {}, 'demo');
 ```
 
+### Running Multiple Flows
+
+Execute several flows at once and receive a map of results:
+
+```typescript
+const runner = new Runner();
+const results = await runner.runAgentFlows(
+  [flowA, flowB],
+  { [flowA.getId()]: ctxA, [flowB.getId()]: ctxB },
+  true,
+);
+```
+
 ---
 
 ## 🧩 Core Components

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -129,7 +129,7 @@ npx ts-node examples/data-pipeline.ts
 ## 🔗 Want More?
 
 - Add a custom node? Extend the `Node` class.
-- Run multi-flows? Use `Runner.runAgentFlows()`.
+ - Run multi-flows? Use `Runner.runAgentFlows()` to execute several flows and get a map of results.
 - Make it stateful? Use `RedisStore` for persistence.
 
 We’d love to see what flows you build! 🚀

--- a/examples/README.md
+++ b/examples/README.md
@@ -117,7 +117,7 @@ npx ts-node examples/data-pipeline.ts
 ## 🔗 Want More?
 
 - Add a custom node? Extend the `Node` class.
-- Run multi-flows? Use `Runner.runAgentFlows()`.
+ - Run multi-flows? Use `Runner.runAgentFlows()` to execute several flows and collect the outputs.
 - Make it stateful? Use `RedisStore` for persistence.
 
 We’d love to see what flows you build! 🚀


### PR DESCRIPTION
## Summary
- expose Flow.getId for external use
- add Runner.runAgentFlows to execute several flows in sequence or in parallel
- document new helper in README and example docs
- test running multiple flows sequentially and in parallel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842cc9009fc832c9bf4dfcd2e893820