### PR TITLE
Add inspect command to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,12 @@ Then run:
 npx aaflow run ./flow.ts
 ```
 
+Inspect a flow without executing it:
+
+```bash
+npx aaflow inspect ./flow.ts
+```
+
 ---
 
 ## 🔐 Extending

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,11 +3,19 @@ import path from 'node:path';
 import { Runner } from './index';
 import type { Flow, Context } from './index';
 
+async function loadModule(modPath: string): Promise<Record<string, unknown>> {
+  const resolved = path.isAbsolute(modPath) ? modPath : path.resolve(process.cwd(), modPath);
+  try {
+    return await import(resolved);
+  } catch {
+    // Fallback for environments without dynamic import support (e.g., Jest)
+     
+    return require(resolved);
+  }
+}
+
 export async function run(flowModulePath: string): Promise<void> {
-  const resolved = path.isAbsolute(flowModulePath)
-    ? flowModulePath
-    : path.resolve(process.cwd(), flowModulePath);
-  const mod = (await import(resolved)) as {
+  const mod = (await loadModule(flowModulePath)) as {
     default?: Flow;
     flow?: Flow;
     context?: Context;
@@ -26,15 +34,42 @@ export async function run(flowModulePath: string): Promise<void> {
   console.log(JSON.stringify(result, null, 2));
 }
 
+export async function inspect(flowModulePath: string): Promise<void> {
+  const mod = (await loadModule(flowModulePath)) as {
+    default?: Flow;
+    flow?: Flow;
+  };
+  const flow: Flow | undefined = mod.flow ?? mod.default;
+  if (!flow) {
+    throw new Error('Flow instance not found. Export `flow` or default.');
+  }
+
+  const nodes = Array.from((flow as any).nodes.values()).map((n: any) => ({
+    id: n.getId(),
+    type: n.constructor.name,
+  }));
+  const transitions: Record<string, Record<string, string>> = {};
+  for (const [from, map] of (flow as any).transitions.entries()) {
+    transitions[from] = Object.fromEntries(map.entries());
+  }
+  const start = (flow as any).startNodeId;
+  const info = { id: flow.getId(), start, nodes, transitions };
+  console.log(JSON.stringify(info, null, 2));
+}
+
 if (require.main === module) {
   const [, , command, file] = process.argv;
-  if (command !== 'run' || !file) {
-    console.log('Usage: aaflow run <path-to-flow-module>');
-    process.exit(command ? 1 : 0);
-  } else {
-    run(file).catch((err) => {
-      console.error(err);
-      process.exit(1);
-    });
+  if (!command || !file) {
+    console.log('Usage: aaflow <run|inspect> <path-to-flow-module>');
+    process.exit(0);
   }
+  const fn = command === 'run' ? run : command === 'inspect' ? inspect : null;
+  if (!fn) {
+    console.log('Usage: aaflow <run|inspect> <path-to-flow-module>');
+    process.exit(1);
+  }
+  fn(file).catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,16 @@
+import path from 'node:path';
+import { inspect } from '../src/cli';
+
+describe('CLI inspect', () => {
+  it('prints flow structure', async () => {
+    const file = path.join(__dirname, 'fixtures', 'simple-flow.js');
+    const log = jest.spyOn(console, 'log').mockImplementation();
+    await inspect(file);
+    expect(log).toHaveBeenCalledTimes(1);
+    const output = JSON.parse(log.mock.calls[0][0] as string);
+    expect(output.start).toBe('start');
+    expect(output.nodes).toContainEqual({ id: 'start', type: 'ActionNode' });
+    expect(output.transitions.start.default).toBe('end');
+    log.mockRestore();
+  });
+});

--- a/tests/fixtures/simple-flow.js
+++ b/tests/fixtures/simple-flow.js
@@ -1,0 +1,9 @@
+const { Flow, ActionNode } = require('../../src/index');
+
+const flow = new Flow('cli-test')
+  .addNode(new ActionNode('start', async () => 'hi'))
+  .addNode(new ActionNode('end', async () => 'done'))
+  .setStartNode('start')
+  .addTransition('start', { action: 'default', to: 'end' });
+
+module.exports = { flow };


### PR DESCRIPTION
## Summary
- implement `aaflow inspect` command to show flow nodes and transitions
- document inspect command in README
- add CLI tests and fixture for inspect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842cf6403f0832c98b1422ecb602901