### PR TITLE
Add plugin system

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,34 @@ const results = await runner.runAgentFlows(
 );
 ```
 
+### Creating and Loading Plugins
+
+Extend `Runner` by providing plugin objects or paths when it is constructed. A plugin is a module exporting `{ name, setup(runner) }`.
+
+```javascript
+// logger-plugin.js
+module.exports = {
+  default: {
+    name: 'logger',
+    setup(runner) {
+      runner.onUpdate((u) => console.log(u));
+    },
+  },
+};
+```
+
+Load plugins using a file path or directory:
+
+```typescript
+import path from 'node:path';
+import { Runner } from 'ai-agent-flow';
+
+const runner = new Runner(3, 1000, undefined, [
+  path.join(__dirname, 'logger-plugin.js'),
+  path.join(__dirname, 'plugins'), // directory of plugins
+]);
+```
+
 ---
 
 ## 🧩 Core Components
@@ -286,6 +314,7 @@ npm run coverage # Generate coverage report
 - [Flow API](./docs/api/flow.md) - Understand Flow creation and management
 - [Runner API](./docs/api/runner.md) - Explore Flow execution and monitoring
 - [Complete API Reference](./docs/api/index.md) - Full API documentation
+- [Plugin Guide](./docs/plugins.md) - Write and load plugins
 
 ### Examples
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,31 @@
+# 🔌 Plugin System
+
+ai-agent-flow supports lightweight plugins that can augment the `Runner` at start up.
+A plugin is any module that exports an object with a `name` and `setup` function.
+
+```javascript
+// my-plugin.js
+module.exports = {
+  default: {
+    name: 'my-plugin',
+    setup(runner) {
+      // interact with the runner instance
+      runner.onUpdate((u) => console.log(u));
+    },
+  },
+};
+```
+
+Load plugins by passing them to the `Runner` constructor either directly, via a file path or a directory of plugin files.
+
+```typescript
+import path from 'node:path';
+import { Runner } from 'ai-agent-flow';
+
+const runner = new Runner(3, 1000, undefined, [
+  path.join(__dirname, 'my-plugin.js'), // single plugin
+  path.join(__dirname, 'plugins'),      // load all plugins in directory
+]);
+```
+
+Each plugin's `setup` method is invoked immediately with the runner instance, allowing it to register hooks or modify behavior.

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,0 +1,35 @@
+export interface Plugin {
+  name: string;
+  setup(runner: import('../index').Runner): void;
+}
+
+import fs from 'fs';
+import path from 'path';
+
+export function loadPluginSync(modPath: string): Plugin | undefined {
+  const resolved = path.isAbsolute(modPath) ? modPath : path.resolve(process.cwd(), modPath);
+  try {
+     
+    const mod = require(resolved);
+    const plugin: Plugin | undefined = mod.default ?? mod.plugin;
+    return plugin;
+  } catch {
+    return undefined;
+  }
+}
+
+export function loadPluginsFromDirSync(dir: string): Plugin[] {
+  const resolvedDir = path.isAbsolute(dir) ? dir : path.resolve(process.cwd(), dir);
+  if (!fs.existsSync(resolvedDir)) return [];
+  const files = fs.readdirSync(resolvedDir);
+  const plugins: Plugin[] = [];
+  for (const file of files) {
+    const full = path.join(resolvedDir, file);
+    const stat = fs.statSync(full);
+    if (stat.isFile()) {
+      const plugin = loadPluginSync(full);
+      if (plugin) plugins.push(plugin);
+    }
+  }
+  return plugins;
+}

--- a/tests/fixtures/example-plugin.js
+++ b/tests/fixtures/example-plugin.js
@@ -1,0 +1,8 @@
+module.exports = {
+  default: {
+    name: 'example-plugin',
+    setup(runner) {
+      runner.exampleInitialized = true;
+    },
+  },
+};

--- a/tests/fixtures/plugins/dir-plugin.js
+++ b/tests/fixtures/plugins/dir-plugin.js
@@ -1,0 +1,8 @@
+module.exports = {
+  default: {
+    name: 'dir-plugin',
+    setup(runner) {
+      runner.dirPluginLoaded = true;
+    },
+  },
+};

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -1,0 +1,33 @@
+import path from 'node:path';
+import { Runner } from '../src/index';
+import { Plugin } from '../src/plugins';
+
+describe('Plugin system', () => {
+  it('registers plugin objects', () => {
+    const plugin: Plugin = {
+      name: 'obj',
+      setup(r) {
+        (r as any).objLoaded = true;
+      },
+    };
+
+    const runner = new Runner(1, 10, undefined, [plugin]);
+    expect(runner.getPlugins().some((p) => p.name === 'obj')).toBe(true);
+    // setup should have run
+    expect((runner as any).objLoaded).toBe(true);
+  });
+
+  it('loads plugins from file paths', () => {
+    const file = path.join(__dirname, 'fixtures', 'example-plugin.js');
+    const runner = new Runner(1, 10, undefined, [file]);
+    expect(runner.getPlugins().some((p) => p.name === 'example-plugin')).toBe(true);
+    expect((runner as any).exampleInitialized).toBe(true);
+  });
+
+  it('loads plugins from directories', () => {
+    const dir = path.join(__dirname, 'fixtures', 'plugins');
+    const runner = new Runner(1, 10, undefined, [dir]);
+    expect(runner.getPlugins().some((p) => p.name === 'dir-plugin')).toBe(true);
+    expect((runner as any).dirPluginLoaded).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce plugin interface
- load plugins from file or directory
- register plugins in Runner
- document plugin usage
- add plugin tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842d0d64fe4832c91eedad223e3e4cb