### PR TITLE
Implement RedisMessageBus

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,18 @@ bus.send('agentA', 'agentB', 'Hello');
 
 This is particularly useful for multi-agent systems where agents need to communicate asynchronously.
 
+#### Choosing a Transport
+
+For single-process apps you can rely on the in-memory `MessageBus`. To enable cross-process messaging, switch to the `RedisMessageBus`:
+
+```typescript
+import { RedisMessageBus } from 'ai-agent-flow/utils/redis-message-bus';
+
+const bus = new RedisMessageBus({ url: 'redis://localhost:6379' });
+```
+
+Both buses expose the same API so you can pick one based on your environment.
+
 ---
 
 ## 📚 Documentation

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export * from './nodes/decision';
 export * from './nodes/batch';
 export * from './types';
 export * from './utils/message-bus';
+export { RedisMessageBus } from './utils/redis-message-bus';
 export * from './store';
 export * from './plugins';
 

--- a/src/utils/redis-message-bus.ts
+++ b/src/utils/redis-message-bus.ts
@@ -1,0 +1,58 @@
+import { EventEmitter } from 'events';
+import Redis from 'ioredis';
+
+export interface RedisMessageBusOptions {
+  publisher?: Redis;
+  subscriber?: Redis;
+  url?: string;
+}
+
+export class RedisMessageBus extends EventEmitter {
+  private publisher: Redis;
+  private subscriber: Redis;
+  private subscribed = new Set<string>();
+
+  constructor(options: RedisMessageBusOptions = {}) {
+    super();
+    if (options.publisher) {
+      this.publisher = options.publisher;
+    } else if (options.url) {
+      this.publisher = new Redis(options.url);
+    } else {
+      this.publisher = new Redis();
+    }
+
+    if (options.subscriber) {
+      this.subscriber = options.subscriber;
+    } else if (options.url) {
+      this.subscriber = new Redis(options.url);
+    } else {
+      this.subscriber = new Redis();
+    }
+
+    this.subscriber.on('message', (channel, message) => {
+      try {
+        const { senderId, payload } = JSON.parse(message);
+        this.emit(channel, senderId, payload);
+      } catch {
+        // ignore malformed messages
+      }
+    });
+  }
+
+  send(senderId: string, receiverId: string, message: unknown): void {
+    void this.publisher.publish(receiverId, JSON.stringify({ senderId, payload: message }));
+  }
+
+  publish(receiverId: string, message: unknown): void {
+    this.send('system', receiverId, message);
+  }
+
+  subscribe(receiverId: string, callback: (senderId: string, message: unknown) => void): void {
+    this.on(receiverId, callback);
+    if (!this.subscribed.has(receiverId)) {
+      this.subscribed.add(receiverId);
+      void this.subscriber.subscribe(receiverId);
+    }
+  }
+}

--- a/tests/redis-message-bus.test.ts
+++ b/tests/redis-message-bus.test.ts
@@ -1,0 +1,48 @@
+import { RedisMessageBus } from '../src/utils/redis-message-bus';
+import { EventEmitter } from 'events';
+
+class MockRedis extends EventEmitter {
+  constructor(private bus: EventEmitter) {
+    super();
+  }
+  async publish(channel: string, message: string) {
+    this.bus.emit(channel, message);
+    return 1;
+  }
+  async subscribe(channel: string) {
+    this.bus.on(channel, (msg) => this.emit('message', channel, msg));
+    return 1;
+  }
+}
+
+describe('RedisMessageBus', () => {
+  it('sends and receives messages', (done) => {
+    const shared = new EventEmitter();
+    const pub = new MockRedis(shared);
+    const sub = new MockRedis(shared);
+    const bus = new RedisMessageBus({ publisher: pub as any, subscriber: sub as any });
+
+    bus.subscribe('agentB', (sender, msg) => {
+      expect(sender).toBe('agentA');
+      expect(msg).toBe('hello');
+      done();
+    });
+
+    bus.send('agentA', 'agentB', 'hello');
+  });
+
+  it('publishes system messages', (done) => {
+    const shared = new EventEmitter();
+    const pub = new MockRedis(shared);
+    const sub = new MockRedis(shared);
+    const bus = new RedisMessageBus({ publisher: pub as any, subscriber: sub as any });
+
+    bus.subscribe('news', (sender, msg) => {
+      expect(sender).toBe('system');
+      expect(msg).toBe('update');
+      done();
+    });
+
+    bus.publish('news', 'update');
+  });
+});


### PR DESCRIPTION
## Summary
- implement Redis-backed message bus
- export RedisMessageBus in library index
- add tests for RedisMessageBus
- document how to choose between in-memory and Redis message bus

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842d56584d0832ca0f7bd6f148d0fec