### PR TITLE
Add CLI run test

### DIFF
--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,5 +1,10 @@
+import fs from 'node:fs';
 import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { inspect } from '../src/cli';
+
+const execFileAsync = promisify(execFile);
 
 describe('CLI inspect', () => {
   it('prints flow structure', async () => {
@@ -12,5 +17,28 @@ describe('CLI inspect', () => {
     expect(output.nodes).toContainEqual({ id: 'start', type: 'ActionNode' });
     expect(output.transitions.start.default).toBe('end');
     log.mockRestore();
+  });
+});
+
+describe('CLI run', () => {
+  it('executes a flow via the CLI', async () => {
+    const file = path.join(__dirname, 'fixtures', 'simple-flow.js');
+
+    const distCli = path.join(__dirname, '..', 'dist', 'cjs', 'cli.js');
+    const srcCli = path.join(__dirname, '..', 'src', 'cli.ts');
+
+    let command = process.execPath;
+    let args = [distCli, 'run', file];
+    const env = { ...process.env };
+
+    if (!fs.existsSync(distCli)) {
+      command = 'npx';
+      args = ['-y', 'ts-node', '-T', srcCli, 'run', file];
+      env.npm_config_yes = 'true';
+    }
+
+    const { stdout } = await execFileAsync(command, args, { env });
+    const output = JSON.parse(stdout.trim());
+    expect(output).toEqual({ type: 'success', output: 'Flow completed' });
   });
 });


### PR DESCRIPTION
## Summary
- add CLI run test that spawns the CLI
- use ts-node when dist build isn't present

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842d86ea7a8832c8b10b5eea62c75d6