### PR TITLE
Fix CLI test timeout

### DIFF
--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -40,5 +40,5 @@ describe('CLI run', () => {
     const { stdout } = await execFileAsync(command, args, { env });
     const output = JSON.parse(stdout.trim());
     expect(output).toEqual({ type: 'success', output: 'Flow completed' });
-  });
+  }, 15000);
 });


### PR DESCRIPTION
## Summary
- adjust CLI test so it uses a 15s timeout for slower environments

## Testing
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_6842e385ad58832ca2978c5c519e647a